### PR TITLE
OS X (Darwin) compatibility for portIsTaken()

### DIFF
--- a/neo4j-instance.sh
+++ b/neo4j-instance.sh
@@ -93,8 +93,14 @@ function setup {
 
 function portIsTaken {
     port=$1;
-    if (netstat -tulpn 2>&1 | sed -e 's/\s\+/ /g' | cut -d " " -f4 >&1 | grep ":$port$" > /dev/null); then
-        return 0;
+    if [ $( uname -s ) == "Darwin" ]; then
+        if lsof -nP -i "4tcp:${port}" -s TCP:LISTEN > /dev/null; then
+            return 0
+        fi
+    else
+        if (netstat -tulpn 2>&1 | sed -e 's/\s\+/ /g' | cut -d " " -f4 >&1 | grep ":$port$" > /dev/null); then
+            return 0;
+        fi
     fi
     return 1;
 }


### PR DESCRIPTION
I was pleasantly surprised to find that this script mostly works on OS X! (once you install a recent version of bash).

`portIsTaken` didn't work, though, the BSD options of netstat are not the same. lsof can be used to the same effect.
