### PR TITLE
fixes to create command

### DIFF
--- a/neo4j-instance.sh
+++ b/neo4j-instance.sh
@@ -8,6 +8,7 @@ startShellPort=1337;
 currentVersion="3.1.1";
 neo4jType="community";
 docker=0;
+instancesDirectory="$HOME/neo4j-instances";
 
 function vercomp {
     if [[ $1 == $2 ]]
@@ -85,14 +86,13 @@ function setup {
     if [ "$username" == 'root' ]; then
         message "script should not be ran as root" "W" "red";
         exit;
-    fi
-
-    if [ -d ~/neo4j-instances ]; then
-        cd ~/neo4j-instances
-    else
-        cd ~;
-        mkdir neo4j-instances;
-        cd ~/neo4j-instances;
+    fi    
+    echo $instancesDirectory
+    if [ -d $instancesDirectory ]; then
+        cd $instancesDirectory
+    else        
+        mkdir -p $instancesDirectory;
+        cd "$instancesDirectory"
     fi
 
     if [ ! -d ports ]; then
@@ -194,7 +194,6 @@ function createDatabase {
             exit;
         fi
     fi
-
     if [ ! -d "ports/$lastPort" ]; then
         message "create database" "X" "green";        
         cp -r $skeletonPath "ports/$lastPort";
@@ -214,8 +213,7 @@ function createDatabase {
         
         if [ -z "$dbName" ]; then
             dbName="untitled$lastPort";
-        fi
-
+        fi        
         echo -n "$dbName" > ports/$lastPort/db-name
         echo -n "$neo4jType" > ports/$lastPort/db-type
         echo -n "$currentVersion" > ports/$lastPort/db-version


### PR DESCRIPTION
The following changes have been made:

In the create function , where it is trying to change the config file
for neo4j.conf and change the ports used, the older string
“dbms.connector.http.address=0.0.0.0:7474” is not used anymore and the
alternative “dbms.connector.http.listen_address=:7474” exists. I
changed the function appropriately to check and change the config file
based on the string used.

Using default names for ports:
At the end of the create function, it was checking if dbName is given
by the user. If yes, it would write multiple files and if not it
wouldn’t write any of them. This was preventing the code to properly
handle multiple databases because one of these files that wouldn’t not
have been written is “shell-port” which is used in the creation of the
next database instance.

The current version generates a name for databases if not determined in
input in the format “untitled<port-number>” and creates all files
regardless of the input. I explained this in the usage descriptions for
create

I tried it and works now for me. 